### PR TITLE
feat: leave guilds that don't match $GUILD_ID

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,6 +1,7 @@
 {
   "prefix": ";;",
   "token": "TOKEN HERE",
+  "guild_id": "GUILD_ID HERE",
   "emoji": {
     "play": "▶️",
     "stop": "⏹️",

--- a/index.js
+++ b/index.js
@@ -58,6 +58,19 @@ client.on('ready', () => {
   client.user.setActivity('Praise be to ;;toromi')
 })
 
+// join a guild
+client.on('guildCreate', guild => {
+  const EXPECTED_GUILD_ID = process.env.GUILD_ID
+  console.log(`Guild: Joined ${guild.name}`)
+
+  if (EXPECTED_GUILD_ID) {
+    if (EXPECTED_GUILD_ID !== guild.id) {
+      console.warn(`Guild: Did not expect to join ${guild.name}. Leaving...`)
+      guild.leave()
+    }
+  }
+})
+
 // lazy (tea) auto role
 client.on('guildMemberAdd', member => {
   member.roles.add(member.guild.roles.cache.find(i => i.name === dmpconfig.defaultrole))

--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ client.on('ready', () => {
 
 // join a guild
 client.on('guildCreate', guild => {
-  const EXPECTED_GUILD_ID = process.env.GUILD_ID
+  const EXPECTED_GUILD_ID = config.guild_id ?? process.env.GUILD_ID
   console.log(`Guild: Joined ${guild.name}`)
 
   if (EXPECTED_GUILD_ID) {

--- a/index.js
+++ b/index.js
@@ -63,11 +63,9 @@ client.on('guildCreate', guild => {
   const EXPECTED_GUILD_ID = config.guild_id ?? process.env.GUILD_ID
   console.log(`Guild: Joined ${guild.name}`)
 
-  if (EXPECTED_GUILD_ID) {
-    if (EXPECTED_GUILD_ID !== guild.id) {
-      console.warn(`Guild: Did not expect to join ${guild.name}. Leaving...`)
-      guild.leave()
-    }
+  if (EXPECTED_GUILD_ID && EXPECTED_GUILD_ID !== guild.id) {
+    console.warn(`Guild: Did not expect to join ${guild.name}. Leaving...`)
+    guild.leave()
   }
 })
 


### PR DESCRIPTION
this prevents denpa-bot from running on a server that isn't the one we expect

note: should add the guild id as the environment variable `$GUILD_ID`