### PR TITLE
Removing auto-server leave

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,17 +65,6 @@ client.on('ready', () => {
   client.user.setActivity('Praise be to ;;toromi')
 })
 
-// join a guild
-client.on('guildCreate', guild => {
-  const EXPECTED_GUILD_ID = config.guild_id ?? process.env.GUILD_ID
-  console.log(`Guild: Joined ${guild.name}`)
-
-  if (EXPECTED_GUILD_ID && EXPECTED_GUILD_ID !== guild.id) {
-    console.warn(`Guild: Did not expect to join ${guild.name}. Leaving...`)
-    guild.leave()
-  }
-})
-
 // lazy (tea) auto role
 client.on('guildMemberAdd', member => {
   member.roles.add(member.guild.roles.cache.find(i => i.name === config.defaultrole))


### PR DESCRIPTION
Originally, Paoda added a check to prevent other servers from adding this Discord bot. This should no longer be necessary, so I will remove it.